### PR TITLE
Video token improvements: always muted by default, module setting to disable autoplay in preview HUD

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -6,6 +6,8 @@
 	"THWildcard.ButtonTitle": "Datei wählen",
 	"THWildcard.DisplaySettingName": "Als Bild anzeigen?",
 	"THWildcard.DisplaySettingHint": "Deaktivieren, um die Bilder stattdessen als Liste von Dateinamen im Auswahl-HUD anzuzeigen. Standard: ein.",
+	"THWildcard.VideoAutoplaySettingName": "Video-Vorschau automatisch abspielen",
+	"THWildcard.VideoAutoplaySettingHint": "Deaktivieren, um Vorschau für Videodateien in der Auswahl-HUD nicht automatisch abzuspielen. Kann bei großer Menge Videodateien die Performance verbessern. Standard: ein.",
 	"THWildcard.OpacitySettingName": "Transparenz der Tokenvorschau",
 	"THWildcard.OpacitySettingHint": "Lege die Transparenz der Token-Vorschau im HUD (bevor der Mauszeiger über sie fährt)  fest. Standard: 50%.",
 	"THWildcard.AnimateSettingName": "Veränderung animieren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,8 @@
 	"THWildcard.ButtonTitle": "Browse File",
 	"THWildcard.DisplaySettingName": "Display as Image?",
 	"THWildcard.DisplaySettingHint": "Disable to display wildcard options as a list of their filenames in the HUD. Default enabled.",
+	"THWildcard.VideoAutoplaySettingName": "Autoplay video previews",
+	"THWildcard.VideoAutoplaySettingHint": "Disable to not autoplay video wildcard tokens in the Token HUD preview. May improvde performance if there are many video files. Default enabled.",
 	"THWildcard.OpacitySettingName": "Opacity of token preview",
 	"THWildcard.OpacitySettingHint": "Configure the opacity of the token previews in the HUD before hovering on them. Default 50%.",
 	"THWildcard.AnimateSettingName": "Animate changes",

--- a/templates/hud.html
+++ b/templates/hud.html
@@ -9,7 +9,7 @@
                             <img class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" />
                         {{/if}}
                         {{#if image.vid}}
-                            <video class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" autoplay loop></video>
+                            <video class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" {{#if ../videoAutoplay}}autoplay{{/if}} muted loop></video>
                         {{/if}}
                     {{else}}
                         <span data-name="{{image.route}}">{{image.name}}</span>

--- a/templates/hud.html
+++ b/templates/hud.html
@@ -9,7 +9,7 @@
                             <img class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" />
                         {{/if}}
                         {{#if image.vid}}
-                            <video class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" autoplay loop />
+                            <video class="thwildcard-button-image" src="{{image.route}}" alt="{{image.name}}" data-name="{{image.route}}" autoplay loop></video>
                         {{/if}}
                     {{else}}
                         <span data-name="{{image.route}}">{{image.name}}</span>

--- a/token-hud-wildcard.js
+++ b/token-hud-wildcard.js
@@ -7,6 +7,14 @@ Hooks.on('init', () => {
         type: Boolean,
         default: true
     });
+    game.settings.register('token-hud-wildcard', 'videoAutoplay', {
+        name: game.i18n.format('THWildcard.VideoAutoplaySettingName'),
+        hint: game.i18n.format('THWildcard.VideoAutoplaySettingHint'),
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true
+    });
     game.settings.register('token-hud-wildcard', 'animate', {
         name: game.i18n.format('THWildcard.AnimateSettingName'),
         hint: game.i18n.format('THWildcard.AnimateSettingHint'),
@@ -98,7 +106,8 @@ Hooks.on('renderTokenHUD', async (app, html, context) => {
     }
 
     const imageDisplay = game.settings.get('token-hud-wildcard', 'imageDisplay');
-    const wildcardDisplay = await renderTemplate('/modules/token-hud-wildcard/templates/hud.html', { images, imageDisplay });
+    const videoAutoplay = game.settings.get('token-hud-wildcard', 'videoAutoplay');
+    const wildcardDisplay = await renderTemplate('/modules/token-hud-wildcard/templates/hud.html', { images, imageDisplay, videoAutoplay });
 
     let right = html.querySelector('div.right');
     right?.insertAdjacentHTML('beforeend', wildcardDisplay);


### PR DESCRIPTION
- Token wildcard videos are now always muted in the preview HUD
- Added a new module setting to disable autoplaying the videos in preview HUD, which may help performance if there is a large number of video files